### PR TITLE
Remove unused escape characters and variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = function (plugs, wrap) {
         // If a callback is not registered to be called back when the servers are
         // fully started, our default behaviour is just to print any errors starting
         // the servers to the log
-        startedCb = (err, result) => {
+        startedCb = (err) => {
           if (err) {
             console.error("Error starting multiserver server: " + err)
           }

--- a/plugins/net.js
+++ b/plugins/net.js
@@ -121,7 +121,7 @@ module.exports = ({ scope = 'device', host, port, external, allowHalfOpen, pause
       }
 
       // Remove IPv6 scopeid suffix, if any, e.g. `%wlan0`
-      resultHost = resultHost.replace(/(\%\w+)$/, '')
+      resultHost = resultHost.replace(/(%\w+)$/, '')
 
       return toAddress(resultHost, port)
     }

--- a/plugins/noauth.js
+++ b/plugins/noauth.js
@@ -1,7 +1,7 @@
 module.exports = function (opts) {
   return {
     name: 'noauth',
-    create: function (_opts) {
+    create: function () {
       return function (stream, cb) {
         cb(null, {
           remote: opts.keys.publicKey,
@@ -12,7 +12,7 @@ module.exports = function (opts) {
         })
       }
     },
-    parse: function (str) {
+    parse: function () {
       return {}
     },
     stringify: function () {

--- a/plugins/onion.js
+++ b/plugins/onion.js
@@ -8,7 +8,7 @@ module.exports = function (opts) {
     return {
       name: 'onion',
       scope: function() { return 'public' },
-      parse: function (s) { return null }
+      parse: function () { return null }
     }
   }
 
@@ -63,7 +63,7 @@ module.exports = function (opts) {
         }
       }
 
-      tryConnect(connectOpts(daemonProxyOpts), function(err) {
+      tryConnect(connectOpts(daemonProxyOpts), function() {
         tryConnect(connectOpts(browserProxyOpts), function(err) {
           cb(err)
         })
@@ -87,7 +87,7 @@ module.exports = function (opts) {
         port: port
       }
     },
-    stringify: function (scope) {
+    stringify: function () {
       return null
     }
   }

--- a/plugins/ws.js
+++ b/plugins/ws.js
@@ -146,7 +146,7 @@ module.exports = function (opts = {}) {
     },
     parse: function (str) {
       var addr = URL.parse(str)
-      if(!/^wss?\:$/.test(addr.protocol)) return null
+      if(!/^wss?:$/.test(addr.protocol)) return null
       return addr
     }
   }

--- a/test/plugs.js
+++ b/test/plugs.js
@@ -1,7 +1,6 @@
 var tape = require('tape')
 var pull = require('pull-stream')
 var Pushable = require('pull-pushable')
-const fs = require('fs')
 
 var Compose = require('../compose')
 var Net = require('../plugins/net')
@@ -165,7 +164,7 @@ tape('net: do not listen on all addresses', function (t) {
 
   var addr = fake_combined.stringify('local') // returns external
   console.log('addr local scope', addr)
-  combined.client(addr, function (err, stream) {
+  combined.client(addr, function (err) {
     t.ok(err, 'should only listen on localhost')
     close(function() {t.end()})
   })
@@ -247,7 +246,7 @@ tape('error if try to connect on wrong protocol', function (t) {
 
   t.equal(combined_ws.parse(combined.stringify()), null)
 
-  combined_ws.client(combined.stringify(), function (err, stream) {
+  combined_ws.client(combined.stringify(), function (err) {
     t.ok(err)
     t.end()
   })
@@ -384,7 +383,7 @@ function testAbort (name, combined) {
       throw new Error('should never happen')
     })
 
-    var abort = combined.client(combined.stringify(), function (err, stream) {
+    var abort = combined.client(combined.stringify(), function (err) {
       t.ok(err)
 
       // NOTE: without the timeout, we try to close the server
@@ -408,10 +407,10 @@ testAbort('combined.ws', combined_ws)
 
 tape('error should have client address on it', function (t) {
   //  return t.end()
-  check = function (id, cb) {
+  check = function () {
     throw new Error('should never happen')
   }
-  var close = combined.server(function (stream) {
+  var close = combined.server(function () {
     throw new Error('should never happen')
   }, function (err) {
     t.ok(/^net:/.test(err.address))
@@ -422,7 +421,7 @@ tape('error should have client address on it', function (t) {
 
     //very unlikely this is the address, which will give a wrong number at the server.
     var addr = combined.stringify().replace(/shs:......../, 'shs:XXXXXXXX')
-    combined.client(addr, function (err, stream) {
+    combined.client(addr, function (err) {
       //client should see client auth rejected
       t.ok(err)
       console.log('Calling close')


### PR DESCRIPTION
Allocating unused variables and using unused escape characters makes it
hard to know which things actually require human attention. Some
runtimes allocate memory for these variables, but I don't think that's a
problem with Node.js.