### PR TITLE
Upgrade tape to 5.0.1, fix tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "chloride": "^2.2.8",
     "pull-pushable": "^2.2.0",
-    "tape": "^4.8.0"
+    "tape": "^5.0.1"
   },
   "scripts": {
     "test": "set -e; for t in test/*.js; do node $t; done"

--- a/test/plugs.js
+++ b/test/plugs.js
@@ -394,7 +394,7 @@ function testAbort (name, combined) {
       // This is messy, combined.server should be a proper async call
       setTimeout( function() {
         console.log('Calling close')
-        close(function() {t.end()})
+        close(t.end)
       }, 500)
     })
 
@@ -426,8 +426,7 @@ tape('error should have client address on it', function (t) {
       //client should see client auth rejected
       t.ok(err)
       console.log('Calling close')
-      close() // in this case, net.server.close(cb) never calls its cb, why?
-      t.end()
+      close(t.end)
     })
   })
 })


### PR DESCRIPTION
We have an outdated version of Tape that allows tests to call `t.end()`
multiple times, which we're apparently doing.

This commit upgrades tape and puts the `t.end()` inside of the `close()`
callback so that it's run after close instead of at random times (in the
middle of other tests).