### PR TITLE
add support for external hostname options to be an array

### DIFF
--- a/compose.js
+++ b/compose.js
@@ -103,11 +103,10 @@ module.exports = function (ary, wrap) {
     parse: parse,
     stringify: function (scope) {
       var _ary = []
-      var proto = head(ary)
-      var trans = tail(ary)
       var v = proto.stringify(scope)
       if(!v) return
       else {
+        // if true, more than one hostname needs to be updated
         if (v.split(';').length > 1) {
           var addresses = v.split(';')
           addresses.forEach(a => {

--- a/compose.js
+++ b/compose.js
@@ -102,14 +102,27 @@ module.exports = function (ary, wrap) {
     },
     parse: parse,
     stringify: function (scope) {
-      var none
-      var _ary = ary.map(function (e) {
-        var v = e.stringify(scope)
-        if(!v) none = true
-        else return v
-      })
-      if(none) return
-      return SE.stringify(_ary)
+      var _ary = []
+      var proto = head(ary)
+      var trans = tail(ary)
+      var v = proto.stringify(scope)
+      if(!v) return
+      else {
+        if (v.split(';').length > 1) {
+          var addresses = v.split(';')
+          addresses.forEach(a => {
+            _ary.push(a)
+          })
+        }
+        else _ary.push(v)
+      }
+      return _ary.map(e => {
+        var singleAddr = [e].concat(trans.map(t => {
+          return t.stringify(scope)
+        }))
+
+        return SE.stringify(singleAddr)
+      }).join(';')
     }
   }
 }

--- a/plugins/net.js
+++ b/plugins/net.js
@@ -121,9 +121,13 @@ module.exports = ({ scope = 'device', host, port, external, allowHalfOpen, pause
       }
 
       // Remove IPv6 scopeid suffix, if any, e.g. `%wlan0`
-      resultHost = resultHost.replace(/(\%\w+)$/, '')
-
-      return toAddress(resultHost, port)
+      return Array.isArray(resultHost)
+      // if an array of external hostnames is supplied,
+      // return all of them in an ';' separated address string
+      ? resultHost.map((h) => {
+        return toAddress(h.replace(/(\%\w+)$/, ''), port)
+      }).join(';')
+      : toAddress(resultHost.replace(/(\%\w+)$/, ''), port)
     }
   }
 }

--- a/plugins/net.js
+++ b/plugins/net.js
@@ -120,14 +120,19 @@ module.exports = ({ scope = 'device', host, port, external, allowHalfOpen, pause
         return null
       }
 
-      // Remove IPv6 scopeid suffix, if any, e.g. `%wlan0`
-      return Array.isArray(resultHost)
-      // if an array of external hostnames is supplied,
-      // return all of them in an ';' separated address string
-      ? resultHost.map((h) => {
-        return toAddress(h.replace(/(\%\w+)$/, ''), port)
-      }).join(';')
-      : toAddress(resultHost.replace(/(\%\w+)$/, ''), port)
+      return formatNetAddress(resultHost)
+
+      function formatNetAddress (resultHost) {
+        // convert to an array for easier formatting
+        if (isString(resultHost)) {
+          resultHost = [resultHost]
+        }
+        
+        return resultHost.map((h) => {
+          // Remove IPv6 scopeid suffix, if any, e.g. `%wlan0`
+          return toAddress(h.replace(/(\%\w+)$/, ''), port)
+        }).join(';')
+      }
     }
   }
 }

--- a/plugins/net.js
+++ b/plugins/net.js
@@ -120,19 +120,15 @@ module.exports = ({ scope = 'device', host, port, external, allowHalfOpen, pause
         return null
       }
 
-      return formatNetAddress(resultHost)
-
-      function formatNetAddress (resultHost) {
-        // convert to an array for easier formatting
-        if (isString(resultHost)) {
-          resultHost = [resultHost]
-        }
-        
-        return resultHost.map((h) => {
-          // Remove IPv6 scopeid suffix, if any, e.g. `%wlan0`
-          return toAddress(h.replace(/(\%\w+)$/, ''), port)
-        }).join(';')
+      // convert to an array for easier formatting
+      if (isString(resultHost)) {
+        resultHost = [resultHost]
       }
+      
+      return resultHost.map((h) => {
+        // Remove IPv6 scopeid suffix, if any, e.g. `%wlan0`
+        return toAddress(h.replace(/(\%\w+)$/, ''), port)
+      }).join(';')
     }
   }
 }

--- a/plugins/ws.js
+++ b/plugins/ws.js
@@ -137,21 +137,22 @@ module.exports = function (opts = {}) {
         return null
       }
 
-      return Array.isArray(resultHost)
-      ? resultHost.map((h) => {
-        return URL.format({
-          protocol: secure ? 'wss' : 'ws',
-          slashes: true,
-          hostname: h,
-          port: (secure ? port == 443 : port == 80) ? undefined : port
-        })
-      }).join(';')
-      : URL.format({
-        protocol: secure ? 'wss' : 'ws',
-        slashes: true,
-        hostname: resultHost,
-        port: (secure ? port == 443 : port == 80) ? undefined : port
-      })
+      return formatWsAddress(resultHost)
+
+      function formatWsAddress(resultHost) {
+        if (typeof resultHost === 'string') {
+          resultHost = [resultHost]
+        }
+
+        return resultHost.map((h) => {
+          return URL.format({
+            protocol: secure ? 'wss' : 'ws',
+            slashes: true,
+            hostname: h,
+            port: (secure ? port == 443 : port == 80) ? undefined : port
+          })
+        }).join(';')
+      }
     },
     parse: function (str) {
       var addr = URL.parse(str)

--- a/plugins/ws.js
+++ b/plugins/ws.js
@@ -130,29 +130,25 @@ module.exports = function (opts = {}) {
 
       const port = opts.server ? opts.server.address().port : opts.port
       const externalHost = targetScope === 'public' && opts.external
-      const resultHost = externalHost || opts.host || scopes.host(targetScope)
+      let resultHost = externalHost || opts.host || scopes.host(targetScope)
 
       if (resultHost == null) {
         // The device has no network interface for a given `targetScope`.
         return null
       }
 
-      return formatWsAddress(resultHost)
-
-      function formatWsAddress(resultHost) {
-        if (typeof resultHost === 'string') {
-          resultHost = [resultHost]
-        }
-
-        return resultHost.map((h) => {
-          return URL.format({
-            protocol: secure ? 'wss' : 'ws',
-            slashes: true,
-            hostname: h,
-            port: (secure ? port == 443 : port == 80) ? undefined : port
-          })
-        }).join(';')
+      if (typeof resultHost === 'string') {
+        resultHost = [resultHost]
       }
+
+      return resultHost.map((h) => {
+        return URL.format({
+          protocol: secure ? 'wss' : 'ws',
+          slashes: true,
+          hostname: h,
+          port: (secure ? port == 443 : port == 80) ? undefined : port
+        })
+      }).join(';')
     },
     parse: function (str) {
       var addr = URL.parse(str)

--- a/plugins/ws.js
+++ b/plugins/ws.js
@@ -137,7 +137,16 @@ module.exports = function (opts = {}) {
         return null
       }
 
-      return URL.format({
+      return Array.isArray(resultHost)
+      ? resultHost.map((h) => {
+        return URL.format({
+          protocol: secure ? 'wss' : 'ws',
+          slashes: true,
+          hostname: h,
+          port: (secure ? port == 443 : port == 80) ? undefined : port
+        })
+      }).join(';')
+      : URL.format({
         protocol: secure ? 'wss' : 'ws',
         slashes: true,
         hostname: resultHost,

--- a/test/plugs.js
+++ b/test/plugs.js
@@ -460,3 +460,132 @@ tape('multiple scopes different hosts', function(t) {
 
   t.end()
 })
+
+tape('net: external is a string', function (t) {
+  var net = Net({
+    external: 'domain.de',
+    scope: 'public',
+    port: '9966',
+    server: {
+      key: null,
+      address: function () { return {port: 9966}}
+    }})
+  t.equal(net.stringify('public'), 'net:domain.de:9966')
+  t.equal(net.stringify('local'), null)
+  t.equal(net.stringify('device'), null)
+  t.end()
+})
+
+tape('net: external is an array', function (t) {
+  var net = Net({
+    external: ['domain.de', 'funtime.net'],
+    scope: 'public',
+    port: '9966',
+    server: {
+      key: null,
+      address: function () { return {port: 9966}}
+    }})
+  t.equal(net.stringify('public'), 'net:domain.de:9966;net:funtime.net:9966')
+  t.equal(net.stringify('local'), null)
+  t.equal(net.stringify('device'), null)
+  t.end()
+})
+
+tape('net: external is an array w/ a single entry & shs transform', function (t) {
+  var net = Net({
+    external: ['domain.de'],
+    scope: 'public',
+    port: '9966',
+    server: {
+      key: null,
+      address: function () { return {port: 9966}}
+    }})
+  var combined = Compose([net, shs])
+  t.equal(
+    combined.stringify('public'),
+    'net:domain.de:9966~shs:+y42DK+BGzqvU00EWMKiyj4fITskSm+Drxq1Dt2s3Yw='
+  )
+  t.end()
+})
+
+tape('net: external is an array w/ multiple entries & shs transform', function (t) {
+  var net = Net({
+    external: ['domain.de', 'funtime.net'],
+    scope: 'public',
+    port: '9966',
+    server: {
+      key: null,
+      address: function () { return {port: 9966}}
+    }})
+  var combined = Compose([net, shs])
+  t.equal(
+    combined.stringify('public'),
+    'net:domain.de:9966~shs:+y42DK+BGzqvU00EWMKiyj4fITskSm+Drxq1Dt2s3Yw=;net:funtime.net:9966~shs:+y42DK+BGzqvU00EWMKiyj4fITskSm+Drxq1Dt2s3Yw='
+  )
+  t.end()
+})
+
+tape('ws: external is a string', function (t) {
+  var ws = Ws({
+    external: 'domain.de',
+    scope: 'public',
+    port: '9966',
+    server: {
+      key: null,
+      address: function () { return {port: 9966}}
+    }})
+  t.equal(ws.stringify('public'), 'ws://domain.de:9966')
+  t.equal(ws.stringify('local'), null)
+  t.equal(ws.stringify('device'), null)
+  t.end()
+})
+
+
+tape('ws: external is an array', function (t) {
+  var ws = Ws({
+    external: ['domain.de', 'funtime.net'],
+    scope: 'public',
+    port: '9966',
+    server: {
+      key: null,
+      address: function () { return {port: 9966}}
+    }})
+  t.equal(ws.stringify('public'), 'ws://domain.de:9966;ws://funtime.net:9966')
+  t.equal(ws.stringify('local'), null)
+  t.equal(ws.stringify('device'), null)
+  t.end()
+})
+
+tape('ws: external is an array w/ a single entry & shs transform', function (t) {
+  var ws = Ws({
+    external: ['domain.de'],
+    scope: 'public',
+    port: '9966',
+    server: {
+      key: null,
+      address: function () { return {port: 9966}}
+    }})
+  var combined = Compose([ws, shs])
+  t.equal(
+    combined.stringify('public'),
+    'ws://domain.de:9966~shs:+y42DK+BGzqvU00EWMKiyj4fITskSm+Drxq1Dt2s3Yw='
+  )
+  t.end()
+})
+
+tape('ws: external is an array w/ multiple entries & shs transform', function (t) {
+  var ws = Ws({
+    external: ['domain.de', 'funtime.net'],
+    scope: 'public',
+    port: '9966',
+    server: {
+      key: null,
+      address: function () { return {port: 9966}}
+    }})
+  var combined = Compose([ws, shs])
+  t.equal(
+    combined.stringify('public'),
+    'ws://domain.de:9966~shs:+y42DK+BGzqvU00EWMKiyj4fITskSm+Drxq1Dt2s3Yw=;ws://funtime.net:9966~shs:+y42DK+BGzqvU00EWMKiyj4fITskSm+Drxq1Dt2s3Yw='
+  )
+  t.end()
+})


### PR DESCRIPTION
working on https://github.com/ssb-js/multiserver/issues/62

This PR includes updates to the `net` and `ws` plugins to allow an array of external hostnames to be included in a scope. Some tweaks to the compose.js file to support it are included as well.

