### PR TITLE
Better error reporting

### DIFF
--- a/compose.js
+++ b/compose.js
@@ -87,7 +87,7 @@ module.exports = function (ary, wrap) {
     server: function (onConnection, onError, onStart) {
       onError = onError || function (err) {
         console.error('server error, from', err.address)
-        console.error(err.stack)
+        console.error(err)
       }
       return asyncify(proto.server(function (stream) {
         compose(


### PR DESCRIPTION
When connecting to a go-ssb peer, the errors it returns are often stackless, `err.stack === ''`, so this console.error is not helpful. I think if we use `console.error(err)` we should be safe because this will report the stack as well as other information, like `err.message` which may be very useful.

Concrete instance of this problem was found here: https://github.com/ssb-ngi-pointer/go-ssb-room/issues/190#issuecomment-825083641