### PR TITLE
update multiserver-scopes to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "debug": "^4.1.1",
     "multicb": "^1.2.2",
-    "multiserver-scopes": "^1.0.0",
+    "multiserver-scopes": "^2.0.0",
     "pull-stream": "^3.6.1",
     "pull-websocket": "^3.4.0",
     "secret-handshake": "^1.1.16",


### PR DESCRIPTION
Simple PR to update multiserver-scopes to 2.0.0 (which in turn is just a mere update of non-private-ip from 1.x to 2.0). I intend to make a new version of multiserver, `3.8.0` (minor), after this.